### PR TITLE
fix logger window size

### DIFF
--- a/Processing/sample logger/sketch_RT_AICHIP_logger/SecondScreen.pde
+++ b/Processing/sample logger/sketch_RT_AICHIP_logger/SecondScreen.pde
@@ -7,6 +7,7 @@ public class PFrame extends JFrame {
     setBounds(100, 100, width, height);
     setLocationRelativeTo(null);
     s = new SecondApplet();
+    s.setframesize(width,height);
     add(s);
 
     s.init();
@@ -20,7 +21,9 @@ public class SecondApplet extends PApplet {
   myTextarea mta1, mta2;
   
   int[] buf     = new int[100];
-int[] inByte  = new int[100];
+  int[] inByte  = new int[100];
+  int width;
+  int height;
 //int[] ad_new  = new int[100];
 //int[] ad_base = new int[100];
 
@@ -29,11 +32,12 @@ int[] inByte  = new int[100];
     ControlFont font = new ControlFont(pfont, 241);
 
   public void setup() {
+    size(width,height);
     cp5 = new ControlP5(this);
-
+    
     background(0);
     noStroke();
-    comp  = new ComPortConnection(20, 20, "COM21", cp5);
+    comp  = new ComPortConnection(20, 20, "COM28", cp5);
     mta1  = new myTextarea(20, 230, 200, 200, cp5, "mta1" );
     mta2  = new myTextarea(230, 230, 200, 200, cp5, "mta2" );
     
@@ -45,14 +49,19 @@ int[] inByte  = new int[100];
 
   public void draw() {
     background(0);
-
+    
     mta1.update();
     mta2.update();
     comp.drawUI();
     
   }
   
-    public void controlEvent(ControlEvent theEvent) {
+  public void setframesize(int wid,int hei){
+    width = wid;
+    height = hei; 
+  }
+  
+  public void controlEvent(ControlEvent theEvent) {
   
     println(theEvent.getController().getName());
   
@@ -76,8 +85,8 @@ int[] inByte  = new int[100];
     }
   
     if (theEvent.getController().getName() == "DISCONNECT" )
-    {
-  
+    {  
+
       if (flag_DISCONNECT_button_created == true) {
         try {
           port.stop();
@@ -194,67 +203,5 @@ int[] inByte  = new int[100];
     
   }
    
-  
-  /**
-   * キーボードを押したときに呼ばれる関数
-   * 右キー,左キーでグラフの描画領域をx方向にシフトさせる
-   * @param event
-   * @return void
-   */
-  void keyPressed() {
-    println(str(key));
-    if (keyCode == LEFT) {
-
-      gyro_graph.range_L -= 0.05; 
-      gyro_graph.range_H -= 0.05;
-
-      acc_graph.range_L -= 0.05;
-      acc_graph.range_H -= 0.05;
-
-      mag_graph.range_L -= 0.05;
-      mag_graph.range_H -= 0.05;
-
-      state_graph.range_L -= 0.05;
-      state_graph.range_H -= 0.05;
-
-      deg_graph.range_L -= 0.05;
-      deg_graph.range_H -= 0.05;
-
-      duty_graph.range_L -= 0.05;
-      duty_graph.range_H -= 0.05;
-
-      voltage_graph.range_L -= 0.05;
-      voltage_graph.range_H -= 0.05;
-
-      temp_graph.range_L -= 0.05;
-      temp_graph.range_H -= 0.05;
-    }
-
-    if (keyCode == RIGHT) {
-      gyro_graph.range_L += 0.05; 
-      gyro_graph.range_H += 0.05;
-
-      acc_graph.range_L += 0.05;
-      acc_graph.range_H += 0.05;
-
-      mag_graph.range_L += 0.05;
-      mag_graph.range_H += 0.05;
-
-      state_graph.range_L += 0.05;
-      state_graph.range_H += 0.05;
-
-      deg_graph.range_L += 0.05;
-      deg_graph.range_H += 0.05;
-
-      duty_graph.range_L += 0.05;
-      duty_graph.range_H += 0.05;
-
-      voltage_graph.range_L += 0.05;
-      voltage_graph.range_H += 0.05;
-
-      temp_graph.range_L += 0.05;
-      temp_graph.range_H += 0.05;
-    }
-  }
 }
 

--- a/Processing/sample logger/sketch_RT_AICHIP_logger/comPortConnection.pde
+++ b/Processing/sample logger/sketch_RT_AICHIP_logger/comPortConnection.pde
@@ -48,7 +48,7 @@ class ComPortConnection {
           .setFont(createFont("arial", 20))
             .setAutoClear(false)
               .setCaptionLabel("");
-    ;
+                ;
     tf.setText(default_comPort);
  
   }

--- a/Processing/sample logger/sketch_RT_AICHIP_logger/sketch_RT_AICHIP_logger.pde
+++ b/Processing/sample logger/sketch_RT_AICHIP_logger/sketch_RT_AICHIP_logger.pde
@@ -88,12 +88,7 @@ int default_height = 1000;
  * @return void
  */
 void setup() 
-{
-  //2画面にするための処理
-  f = new PFrame(500, 500);
-  f.setTitle("control window");
-  
-  
+{  
   //ボタン等のUIを使用するためのクラス
   ControlP5 cp5 = new ControlP5(this);
   
@@ -101,7 +96,7 @@ void setup()
   scale_change = (displayWidth * 0.9) /default_width;
   int wid = (int)(displayWidth * 0.9);
   int hei = (int)(default_height*scale_change  );
-  
+ 
   if(hei < displayHeight *0.9){
     size(wid,hei); 
   }
@@ -111,12 +106,16 @@ void setup()
     hei = (int)( (float)default_height * scale_change);
     size(wid,hei); 
   }
-  
+
   //画面等の初期化
   background(0);
   frameRate(60);
   PFont  myfont = createFont( "Arial" , 30 );
   textFont( myfont );
+  
+  //2画面にするための処理
+  f = new PFrame(500, 500);
+  f.setTitle("control window");
   
   //各種グラフをframeに追加
   


### PR DESCRIPTION
<!-- プルリクエストのタイトルと以下の記述項目は、日本語で書いても良いです -->

# What does this implement/fix?
<!-- Explain your changes here. -->
<!-- このPRはどんな機能改善/修正ですか？ -->
Processingを使ったデータロガーのグラフ画面が小さい画面で表示され、グラフ範囲が正常に表示されない状態を修正した。

正常画面
![スクリーンショット 2021-02-16 16 50 23](https://user-images.githubusercontent.com/47343458/108033608-99e0d580-7077-11eb-897b-b1bca3f7fb81.png)

異常画面
![スクリーンショット 2020-12-10 11 57 46](https://user-images.githubusercontent.com/47343458/108033631-a402d400-7077-11eb-922c-5de5d38d4a9d.png)

# Checklists
<!-- PR作成時にチェックボックスにチェックを入れてください -->

- [x] <!-- コントリビューティングガイドラインを読みました--> I have read the CONTRIBUTING guidelines.
- [x] <!-- 同じ変更を要求するオープンなPRが無いことを確認しました --> I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.
